### PR TITLE
Fix link to the Downshift examples in Codesandbox

### DIFF
--- a/src/docs/hooks/useCombobox.mdx
+++ b/src/docs/hooks/useCombobox.mdx
@@ -887,6 +887,8 @@ To see more cool stuff you can build with `useCombobox`, explore the [examples r
   https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useCombobox/action-props.js
 [code-sandbox-react-virtual]:
   https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useCombobox/react-virtual.js
+[examples-code-sandbox]:
+  https://codesandbox.io/s/github/kentcdodds/downshift-examples
 [react-virtual-github]:
   https://github.com/tannerlinsley/react-virtual
 [react-virtualized-github]:

--- a/src/docs/hooks/useMultipleSelection.mdx
+++ b/src/docs/hooks/useMultipleSelection.mdx
@@ -314,9 +314,15 @@ is up to the developer.
   }}
 </Playground>
 
+## Other usage examples
+
+To see more cool stuff you can build with `useMultipleSelection`, explore the [examples repository][examples-code-sandbox].
+
 [use-multiple-selection-github]:
   https://github.com/downshift-js/downshift/tree/master/src/hooks/useMultipleSelection
 [code-sandbox-combobox-usage]:
   https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useMultipleSelection/combobox.js
 [code-sandbox-select-usage]:
   https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useMultipleSelection/select.js
+[examples-code-sandbox]:
+  https://codesandbox.io/s/github/kentcdodds/downshift-examples

--- a/src/docs/hooks/useSelect.mdx
+++ b/src/docs/hooks/useSelect.mdx
@@ -713,6 +713,10 @@ the [react-virtual github link][react-virtual-github].
   }}
 </Playground>
 
+## Other usage examples
+
+To see more cool stuff you can build with `useSelect`, explore the [examples repository][examples-code-sandbox].
+
 [select-aria]:
   https://www.w3.org/TR/wai-aria-practices/examples/listbox/listbox-collapsible.html
 [mdn-select]:
@@ -735,6 +739,8 @@ the [react-virtual github link][react-virtual-github].
   https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useSelect/action-props.js
 [code-sandbox-react-virtual]:
   https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useSelect/react-virtual.js
+[examples-code-sandbox]:
+  https://codesandbox.io/s/github/kentcdodds/downshift-examples
 [react-virtual-github]:
   https://github.com/tannerlinsley/react-virtual
 [react-virtualized-github]:


### PR DESCRIPTION
## Fix

This fixes the link to the Downshift examples repo in Codesandbox on the `useCombobox` [page](https://www.downshift-js.com/use-combobox).

Alternatively, this link could go to the repo https://github.com/downshift-js/downshift-examples

## Current

![Screen Shot 2021-01-21 at 1 35 12 PM](https://user-images.githubusercontent.com/11774595/105402875-8fa0f800-5bed-11eb-853d-872d98238f11.png)
