### PR TITLE
fix: update downshift and fix examples

### DIFF
--- a/docs/hooks/useCombobox.mdx
+++ b/docs/hooks/useCombobox.mdx
@@ -805,7 +805,11 @@ function ComboBoxExample() {
                   'py-2 px-3 shadow-sm flex gap-3 items-center',
                 )}
                 key={`${item.value}${index}`}
-                {...getItemProps({item, index})}
+                {...getItemProps({
+                  item,
+                  index,
+                  'aria-selected': selectedItems.includes(item),
+                })}
               >
                 <input
                   placeholder="Best book ever"

--- a/docs/hooks/useSelect.mdx
+++ b/docs/hooks/useSelect.mdx
@@ -660,7 +660,11 @@ function SelectExample() {
                   'py-2 px-3 shadow-sm flex gap-3 items-center',
                 )}
                 key={`${item.value}${index}`}
-                {...getItemProps({item, index})}
+                {...getItemProps({
+                  item,
+                  index,
+                  'aria-selected': selectedItems.includes(item),
+                })}
               >
                 <input
                   type="checkbox"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@material-ui/icons": "^4.11.3",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.1.1",
-    "downshift": "^7.0.0-alpha.1",
+    "downshift": "^7.0.0",
     "my-loaders": "file:plugins/my-loaders",
     "prism-react-renderer": "^1.3.1",
     "react": "^17.0.2",


### PR DESCRIPTION
Update to v7 and give proper values to `aria-selected` in items for the basic multiple selection examples.