### PR TITLE
docs: add links to the v7 migration guide

### DIFF
--- a/docs/hooks/index.mdx
+++ b/docs/hooks/index.mdx
@@ -17,3 +17,11 @@ is actioned by a button (a **select**, basically), then use
 If you need to add multiple selection for any of them and have the selected
 items act as a Tag List next to the _select_ or _combobox_, then
 [useMultipleSelection](/use-multiple-selection) is the right tool for that.
+
+## Breaking Changes in v7
+
+Since version 7, the _useSelect_ and _useCombobox_ hooks to support the ARIA 1.2
+pattern for the combobox, which contains some changes from the ARIA 1.1 pattern.
+This brings changes in the API and the behaviour of _useCombobox_, detailed in
+the
+[migration page](https://github.com/downshift-js/downshift/blob/master/src/hooks/MIGRATION_V7.md).

--- a/docs/hooks/useCombobox.mdx
+++ b/docs/hooks/useCombobox.mdx
@@ -30,6 +30,13 @@ implement the corresponding ARIA pattern. Every functionality needed should be
 provided out-of-the-box: menu toggle, item selection and up/down movement
 between them, screen reader support, focus management etc.
 
+## Breaking Changes in v7
+
+Since version 7, _useCombobox_ to supports the ARIA 1.2 pattern for the
+combobox, which contains some changes from the ARIA 1.1 pattern. This brings
+changes in the API and the behaviour of _useCombobox_, detailed in the
+[migration page][migration-guide-v7].
+
 ## Props used in examples
 
 In the examples below, we use the _useCombobox_ hook and destructure from its
@@ -1119,3 +1126,5 @@ repository][examples-code-sandbox].
 [react-virtual-github]: https://github.com/tannerlinsley/react-virtual
 [react-virtualized-github]: https://github.com/bvaughn/react-virtualized
 [react-window-github]: https://github.com/bvaughn/react-window
+[migration-guide-v7]:
+  https://github.com/downshift-js/downshift/tree/master/src/hooks/MIGRATION_V7.md#usecombobox

--- a/docs/hooks/useSelect.mdx
+++ b/docs/hooks/useSelect.mdx
@@ -29,6 +29,13 @@ implement the corresponding ARIA pattern. Every functionality needed should be
 provided out-of-the-box: menu toggle, item selection and up/down movement
 between them, screen reader support, highlight by character keys etc.
 
+## Breaking Changes in v7
+
+Since version 7, _useSelect_ to supports the ARIA 1.2 pattern for the combobox,
+which contains some changes from the ARIA 1.1 pattern. This brings changes in
+the API and the behaviour of _useSelect_, detailed in the [migration
+page][migration-guide-v7].
+
 ## Props used in examples
 
 In the examples below, we use the _useSelect_ hook and destructure the getter
@@ -940,3 +947,5 @@ repository][examples-code-sandbox].
 [react-virtual-github]: https://github.com/tannerlinsley/react-virtual
 [react-virtualized-github]: https://github.com/bvaughn/react-virtualized
 [react-window-github]: https://github.com/bvaughn/react-window
+[migration-guide-v7]:
+  https://github.com/downshift-js/downshift/tree/master/src/hooks/MIGRATION_V7.md#useselect


### PR DESCRIPTION
Add links in the hooks pages to the v7 migration guide, to be easier to find.