### PR TITLE
🐛 fix(select): header link overlaps with select dropdown.

### DIFF
--- a/docs/downshift.mdx
+++ b/docs/downshift.mdx
@@ -147,7 +147,7 @@ function ComboBox() {
             </div>
           </div>
           <ul
-            className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 ${
+            className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 z-10 ${
               !(isOpen && items.length) && 'hidden'
             }`}
             {...getMenuProps()}
@@ -261,7 +261,7 @@ function ComboBox() {
             </div>
           </div>
           <ul
-            className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 ${
+            className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 z-10 ${
               !(isOpen && items.length) && 'hidden'
             }`}
             {...getMenuProps()}

--- a/docs/hooks/useCombobox.mdx
+++ b/docs/hooks/useCombobox.mdx
@@ -143,7 +143,7 @@ function ComboBoxExample() {
           </div>
         </div>
         <ul
-          className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 ${
+          className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 z-10 ${
             !(isOpen && items.length) && 'hidden'
           }`}
           {...getMenuProps()}
@@ -400,7 +400,7 @@ function ComboBoxExample() {
           </div>
         </div>
         <ul
-          className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 ${
+          className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 z-10 ${
             !(isOpen && items.length) && 'hidden'
           }`}
           {...getMenuProps()}
@@ -553,7 +553,7 @@ function ComboBoxExample() {
           </div>
         </div>
         <ul
-          className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 ${
+          className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 z-10 ${
             !(isOpen && items.length) && 'hidden'
           }`}
           {...getMenuProps()}
@@ -664,7 +664,7 @@ function ComboBoxExample() {
           </div>
         </div>
         <ul
-          className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 ${
+          className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 z-10 ${
             !(isOpen && items.length) && 'hidden'
           }`}
           {...getMenuProps()}
@@ -830,7 +830,7 @@ function ComboBoxExample() {
           </div>
         </div>
         <ul
-          className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 ${
+          className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 z-10 ${
             !(isOpen && items.length) && 'hidden'
           }`}
           {...getMenuProps()}
@@ -965,7 +965,7 @@ function ComboBoxExample() {
           </div>
         </div>
         <ul
-          className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 ${
+          className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 z-10 ${
             !(isOpen && items.length) && 'hidden'
           }`}
           {...getMenuProps()}
@@ -1091,7 +1091,7 @@ function ComboBoxExample() {
           </div>
         </div>
         <ul
-          className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 ${
+          className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 z-10 ${
             !(isOpen && items.length) && 'hidden'
           }`}
           {...getMenuProps({ref: listRef})}

--- a/docs/hooks/useMultipleSelection.mdx
+++ b/docs/hooks/useMultipleSelection.mdx
@@ -236,7 +236,7 @@ function MultipleComboBoxExample() {
           </div>
         </div>
         <ul
-          className={`absolute w-inherit bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 ${
+          className={`absolute w-inherit bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 z-10 ${
             !(isOpen && items.length) && 'hidden'
           }`}
           {...getMenuProps()}
@@ -388,7 +388,7 @@ function MultipleSelectExample() {
           </div>
         </div>
         <ul
-          className={`absolute w-inherit bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 ${
+          className={`absolute w-inherit bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 z-10 ${
             !(isOpen && items.length) && 'hidden'
           }`}
           {...getMenuProps()}

--- a/docs/hooks/useSelect.mdx
+++ b/docs/hooks/useSelect.mdx
@@ -110,7 +110,7 @@ function SelectExample() {
           </div>
         </div>
         <ul
-          className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 ${
+          className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 z-10 ${
             !isOpen && 'hidden'
           }`}
           {...getMenuProps()}
@@ -320,7 +320,7 @@ function SelectExample() {
           </div>
         </div>
         <ul
-          className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 ${
+          className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 z-10 ${
             !isOpen && 'hidden'
           }`}
           {...getMenuProps()}
@@ -445,7 +445,7 @@ function SelectExample() {
           </div>
         </div>
         <ul
-          className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 ${
+          className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 z-10 ${
             !isOpen && 'hidden'
           }`}
           {...getMenuProps()}
@@ -533,7 +533,7 @@ function SelectExample() {
           </div>
         </div>
         <ul
-          className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 ${
+          className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 z-10 ${
             !isOpen && 'hidden'
           }`}
           {...getMenuProps()}
@@ -673,7 +673,7 @@ function SelectExample() {
           </div>
         </div>
         <ul
-          className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 ${
+          className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 z-10 ${
             !isOpen && 'hidden'
           }`}
           {...getMenuProps()}
@@ -793,7 +793,7 @@ function SelectExample() {
           </div>
         </div>
         <ul
-          className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 ${
+          className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 z-10 ${
             !isOpen && 'hidden'
           }`}
           {...getMenuProps()}
@@ -894,7 +894,7 @@ function SelectExample() {
           </div>
         </div>
         <ul
-          className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 ${
+          className={`absolute w-72 bg-white mt-1 shadow-md max-h-80 overflow-scroll p-0 z-10 ${
             !isOpen && 'hidden'
           }`}
           {...getMenuProps()}


### PR DESCRIPTION
@kentcdodds I was exploring downshift js docs and found out that when we open the dropdown it overlaps with the header link. Refer to below video.
https://www.loom.com/share/2e20b45b32cc4471acdd4c64c82acad3?sid=efdb4685-5cb9-4d6d-a036-6d18f0e29bd4