### PR TITLE
fix(codesandbox): add moduleview to links

### DIFF
--- a/docs/downshift.mdx
+++ b/docs/downshift.mdx
@@ -330,10 +330,10 @@ repository][examples-code-sandbox].
   https://cdb.reacttraining.com/use-a-render-prop-50de598f11ce
 [github-page]: https://github.com/downshift-js/downshift
 [code-sandbox-get-root-props]:
-  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/downshift/ordered-examples/01-basic-autocomplete.js
+  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/downshift/ordered-examples/01-basic-autocomplete.js&moduleview=1
 [code-sandbox-no-get-root-props]:
-  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/downshift/ordered-examples/00-get-root-props-example.js
+  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/downshift/ordered-examples/00-get-root-props-example.js&moduleview=1
 [examples-code-sandbox]:
-  https://codesandbox.io/s/github/kentcdodds/downshift-examples
+  https://codesandbox.io/s/github/kentcdodds/downshift-examples?moduleview=1
 [migration-guide-v8]:
   https://github.com/downshift-js/downshift/tree/master/src/hooks/MIGRATION_V8.md

--- a/docs/hooks/useCombobox.mdx
+++ b/docs/hooks/useCombobox.mdx
@@ -793,7 +793,7 @@ function ComboBoxExample() {
         setItems(books.filter(getBooksFilter(inputValue)))
       },
       items,
-       // there's no actual selection happening in the hook, we're doing it custom via selectedItems.
+      // there's no actual selection happening in the hook, we're doing it custom via selectedItems.
       selectedItem: null,
       itemToString(item) {
         return item ? item.title : ''
@@ -1183,23 +1183,23 @@ repository][examples-code-sandbox].
 [use-combobox-github]:
   https://github.com/downshift-js/downshift/tree/master/src/hooks/useCombobox
 [code-sandbox-basic-usage]:
-  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useCombobox/basic-usage.js
+  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useCombobox/basic-usage.js&moduleview=-1
 [code-sandbox-material-ui-usage]:
-  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useCombobox/material-ui/index.js
+  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useCombobox/material-ui/index.js&moduleview=-1
 [code-sandbox-controlling-state]:
-  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useCombobox/controlling-state.js
+  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useCombobox/controlling-state.js&moduleview=-1
 [code-sandbox-state-reducer]:
-  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useCombobox/state-reducer.js
+  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useCombobox/state-reducer.js&moduleview=-1
 [code-sandbox-custom-window]:
-  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useCombobox/iframe.js
+  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useCombobox/iframe.js&moduleview=-1
 [code-sandbox-basic-multiple-selection]:
-  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useCombobox/basic-multiple-selection.js
+  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useCombobox/basic-multiple-selection.js&moduleview=-1
 [code-sandbox-action-props]:
-  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useCombobox/action-props.js
+  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useCombobox/action-props.js&moduleview=-1
 [code-sandbox-react-virtual]:
-  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useCombobox/react-virtual.js
+  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useCombobox/react-virtual.js&moduleview=-1
 [examples-code-sandbox]:
-  https://codesandbox.io/s/github/kentcdodds/downshift-examples
+  https://codesandbox.io/s/github/kentcdodds/downshift-examples?moduleview=-1
 [react-virtual-github]: https://github.com/tannerlinsley/react-virtual
 [react-virtualized-github]: https://github.com/bvaughn/react-virtualized
 [react-window-github]: https://github.com/bvaughn/react-window

--- a/docs/hooks/useMultipleSelection.mdx
+++ b/docs/hooks/useMultipleSelection.mdx
@@ -445,10 +445,10 @@ To see more cool stuff you can build with _useMultipleSelection_, explore the
 [use-multiple-selection-github]:
   https://github.com/downshift-js/downshift/tree/master/src/hooks/useMultipleSelection
 [code-sandbox-combobox-usage]:
-  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useMultipleSelection/combobox.js
+  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useMultipleSelection/combobox.js&moduleview=-1
 [code-sandbox-select-usage]:
-  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useMultipleSelection/select.js
+  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useMultipleSelection/select.js&moduleview=-1
 [examples-code-sandbox]:
-  https://codesandbox.io/s/github/kentcdodds/downshift-examples
+  https://codesandbox.io/s/github/kentcdodds/downshift-examples?moduleview=-1
 [migration-guide-v8]:
   https://github.com/downshift-js/downshift/tree/master/src/hooks/MIGRATION_V8.md

--- a/docs/hooks/useSelect.mdx
+++ b/docs/hooks/useSelect.mdx
@@ -664,7 +664,7 @@ function SelectExample() {
       items: books,
       itemToString,
       stateReducer,
-       // there's no actual selection happening in the hook, we're doing it custom via selectedItems.
+      // there's no actual selection happening in the hook, we're doing it custom via selectedItems.
       selectedItem: null,
       onSelectedItemChange: ({selectedItem}) => {
         if (!selectedItem) {
@@ -808,7 +808,9 @@ function SelectExample() {
                 },
               })}
             >
-              <span>{selectedItem ? selectedItem.title : 'Best book ever'}</span>
+              <span>
+                {selectedItem ? selectedItem.title : 'Best book ever'}
+              </span>
               <span className="px-2">
                 {isOpen ? <>&#8593;</> : <>&#8595;</>}
               </span>
@@ -984,23 +986,23 @@ repository][examples-code-sandbox].
 [use-select-github]:
   https://github.com/downshift-js/downshift/tree/master/src/hooks/useSelect
 [code-sandbox-basic-usage]:
-  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useSelect/basic-usage.js
+  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useSelect/basic-usage.js&moduleview=1
 [code-sandbox-material-ui-usage]:
-  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useSelect/material-ui/index.js
+  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useSelect/material-ui/index.js&moduleview=1
 [code-sandbox-controlling-state]:
-  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useSelect/controlling-state.js
+  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useSelect/controlling-state.js&moduleview=1
 [code-sandbox-state-reducer]:
-  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useSelect/state-reducer.js
+  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useSelect/state-reducer.js&moduleview=1
 [code-sandbox-custom-window]:
-  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useSelect/iframe.js
+  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useSelect/iframe.js&moduleview=1
 [code-sandbox-basic-multiple-selection]:
-  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useSelect/basic-multiple-selection.js
+  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useSelect/basic-multiple-selection.js&moduleview=1
 [code-sandbox-action-props]:
-  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useSelect/action-props.js
+  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useSelect/action-props.js&moduleview=1
 [code-sandbox-react-virtual]:
-  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useSelect/react-virtual.js
+  https://codesandbox.io/s/github/kentcdodds/downshift-examples?file=/src/hooks/useSelect/react-virtual.js&moduleview=1
 [examples-code-sandbox]:
-  https://codesandbox.io/s/github/kentcdodds/downshift-examples
+  https://codesandbox.io/s/github/kentcdodds/downshift-examples?moduleview=1
 [react-virtual-github]: https://github.com/tannerlinsley/react-virtual
 [react-virtualized-github]: https://github.com/bvaughn/react-virtualized
 [react-window-github]: https://github.com/bvaughn/react-window


### PR DESCRIPTION
Add `moduleview=1` query parameter to fix the examples in the code sandbox and actually see the usage example.

Fixes https://github.com/downshift-js/downshift/issues/1570